### PR TITLE
Add 2 test for color sensor

### DIFF
--- a/tests/pup/sensors/color_arguments.py
+++ b/tests/pup/sensors/color_arguments.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2020 The Pybricks Authors
+
+"""
+Hardware Module: 1
+
+Description: 
+	Verify that ambient() and reflection() refuse an argument
+"""
+
+from pybricks.pupdevices import ColorSensor
+from pybricks.parameters import Port
+
+# Initialize devices.
+color_sensor = ColorSensor(Port.B)
+
+# Get the ambient light intensity.
+ambientD = color_sensor.ambient()
+
+# verify an argument passed to ambient is refused
+expected = "function doesn't take keyword arguments"
+try:
+    ambientT = color_sensor.ambient(surface=True)
+except Exception as e:
+    assert str(e) == expected, "Expected '{0}' == '{1}'".format(
+        e, expected
+    )
+
+# Get the reflected light intensity.
+reflectionD = color_sensor.reflection()
+
+# verify an argument passed to ambient is refused
+expected = "function doesn't take keyword arguments"
+try:
+    reflectionT = color_sensor.reflection(surface=True)
+except Exception as e:
+    assert str(e) == expected, "Expected '{0}' == '{1}'".format(
+        e, expected
+    )

--- a/tests/pup/sensors/color_default.py
+++ b/tests/pup/sensors/color_default.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2020 The Pybricks Authors
+
+"""
+Hardware Module: 1
+
+Description: Verifies color sensor arguments,
+    by asserting that the same colors are reported by
+		using the default argument, e.g. surface=True
+		and using NO argument
+"""
+
+from pybricks.pupdevices import ColorSensor
+from pybricks.parameters import Port
+
+# Initialize devices.
+color_sensor = ColorSensor(Port.B)
+
+# verify that the default and NO-argument calls report the same color
+# assume that the lighting will not change a lot during measuring
+hsvD = color_sensor.hsv()
+hsvT = color_sensor.hsv(surface=True)  # the default
+# do not use surface=False in this test as that causes a mode switch
+# and that would need more time
+assert hsvD == hsvT, "Expected default '{0}' == '{1}'".format(
+        hsvD, hsvT
+    )
+
+colorD = color_sensor.color()
+colorT = color_sensor.color(surface=True)  # the default
+assert colorD == colorT, "Expected default '{0}' == '{1}'".format(
+        colorD, colorT
+    )


### PR DESCRIPTION
color_arguments.py: Verify that ambient() and reflection() refuse an argument 

color_default.py 
  Verifies color sensor arguments, by asserting that the same colors are reported by using the default argument, e.g. surface=True
  and using NO argument